### PR TITLE
Support for multiple parameters

### DIFF
--- a/FixPlaySound.pl
+++ b/FixPlaySound.pl
@@ -35,7 +35,7 @@ sub process {
 	$^I = ".bak";
 	while (<>)
 	{
-		if (/(^.*PlaySound\()"(\w+)"(\).*)/) {
+		if (/(^.*PlaySound\()"(\w+)"(.*)/) {
 		# grab 3 pieces, before, symbol, and after
 			my $before = $1;
 			my $symbol = $2;


### PR DESCRIPTION
The `PlaySound()` function also supports a second parameter which indicates the channel. This was not being picked up by the original version of this script.

Here are two examples from my Addons directory:

```
Rarity/Core.lua:                                        PlaySound("ReadyCheck", "master")
_NPCScan/_NPCScan.lua:                  _G.PlaySound("TellMessage", "master")
```

While the script processes these two files, the regex which does the change is too restrictive and only accepts the single parameter version. This PR changes the regex to support the second parameter. Here are some tests to show the regex works:

https://regex101.com/r/3aD5A0/1/tests